### PR TITLE
Add Support For PowerShell 5.1

### DIFF
--- a/AWSSSOHelper.psd1
+++ b/AWSSSOHelper.psd1
@@ -15,7 +15,7 @@ RootModule = 'AWSSSOHelper.psm1'
 ModuleVersion = '0.0.21'
 
 # Supported PSEditions
-CompatiblePSEditions = @('Core')
+CompatiblePSEditions = @('Core','Desktop')
 
 # ID used to uniquely identify this module>
 GUID = '4116f348-ea11-47fb-95ec-a624dcf70754'
@@ -37,7 +37,7 @@ https://github.com/e0c615c8e4d846ef817cd5063a88716c/AWSSSOHelper
 '@
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '6.0'
+PowerShellVersion = '5.1'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''

--- a/AWSSSOHelper.psd1
+++ b/AWSSSOHelper.psd1
@@ -99,13 +99,13 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        # Tags = @()
+        Tags = @('AWS', 'SSO')
 
         # A URL to the license for this module.
-        # LicenseUri = ''
+        LicenseUri = 'https://github.com/e0c615c8e4d846ef817cd5063a88716c/AWSSSOHelper/blob/master/LICENSE'
 
         # A URL to the main website for this project.
-        # ProjectUri = ''
+        ProjectUri = 'https://github.com/e0c615c8e4d846ef817cd5063a88716c/AWSSSOHelper'
 
         # A URL to an icon representing this module.
         # IconUri = ''

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -1,5 +1,3 @@
-#Requires -PSEdition Core
-
 <#
 .SYNOPSIS
 This is a simple utility script that allows you to retrieve credentials for AWS accounts that are secured using AWS SSO.  Access tokens are cached locally to prevent the need to be pushed to a web browser each time you invoke the script (this is similar behaviour to aws cli v2).
@@ -46,11 +44,17 @@ function Get-AWSSSORoleCredential {
         [string]$Path = (Join-Path $Home ".awsssohelper")
     )
 
-    # Manually import the AWSPowerShell.NetCore module if present as it is not configured for auto-loading
-    $awsNetCorePowerShellModuleName = 'AWSPowerShell.NetCore'
-    if ((Get-Module -Name $awsNetCorePowerShellModuleName -ListAvailable).Count -gt 0)
+    # Manually import the AWSPowerShell module if present as it is not configured for auto-loading
+    if ($PSVersionTable.PSEdition -ne 'Core') {
+        $awsPowerShellModuleName = 'AWSPowerShell'
+    }
+    else {
+        $awsPowerShellModuleName = 'AWSPowerShell.NetCore'
+    }
+
+    if ((Get-Module -Name $awsPowerShellModuleName -ListAvailable).Count -gt 0)
     {
-        Import-Module -Name $awsNetCorePowerShellModuleName
+        Import-Module -Name $awsPowerShellModuleName
     }
 
     if ($Region) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added support for AWS.Tools PowerShell Modules
   ([issue #2](https://github.com/e0c615c8e4d846ef817cd5063a88716c/AWSSSOHelper/issues/2)).
+- Added support for Windows Powershell v5.1
 
 ## [0.0.21] - 2020-05-11
 

--- a/README.md
+++ b/README.md
@@ -9,20 +9,26 @@ A basic set of functionality is included, potential future enhancements could be
 - Additional logic to identify expired Session Tokens and automatically renew (safest for now is to renew ahead of any command execution) - **Done**
 - Improved support for systems without GUI - **Done**
 - Usage of aws cli credential cache
-- Support for PowerShell 5.1
+- Support for PowerShell 5.1 - **Done**
 - Error handling
 - ...
 
 ## Pre-requisites
 
-- PowerShell Core
+- PowerShell 5.1 or Core
 - Default AWS Region configured (Set-DefaultAWSRegion)
-- Either the AWS PowerShell.NetCore or the required AWS.Tools PowerShell modules installed. See [What are the AWS Tools for PowerShell?](https://docs.aws.amazon.com/powershell/latest/userguide/pstools-welcome.html) for information on the differences in the modules.
+- Either the `AWSPowerShell`, `AWS PowerShell.NetCore` or the required `AWS.Tools` PowerShell modules installed. See [What are the AWS Tools for PowerShell?](https://docs.aws.amazon.com/powershell/latest/userguide/pstools-welcome.html) for information on the differences in the modules.
 
-#### Install AWS PowerShell.NetCore Module
+#### Install AWS PowerShell.NetCore Module (for PowerShell Core)
 
 ```powershell
 Install-Module AWSPowerShell.NetCore -Force
+```
+
+#### Install AWS PowerShell Module (for PowerShell 5.1)
+
+```powershell
+Install-Module AWSPowerShell -Force
 ```
 
 #### Install AWS Tools Modules


### PR DESCRIPTION
#### Description

This PR adds support for PowerShell 5.1, using both the new `AWS.Tools` PowerShell module and the legacy `AWSPowerShell` module.

It also adds site link, license and tag metadata to the psd1 file for use by PowerShell Gallery.
 