### PR TITLE
Add Support for Additional Credential Output Options

### DIFF
--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -20,6 +20,8 @@
     If specified, credentials for all roles and accounts will be obtained.
 .PARAMETER ClientName
     The friendly name for the SSO OIDC Client.
+.PARAMETER ClientType
+    The SSO OIDC Client type. This is currently fixed with a value of 'Public'.
 .PARAMETER RefreshAccessToken
     If specified, the SSO access token will be refreshed.
 .PARAMETER Region
@@ -137,7 +139,9 @@ function Get-AWSSSORoleCredential {
         [switch]$PassThru,
 
         [Parameter()]
-        [string]$ClientName = "default",
+        [Parameter()]
+        [ValidateSet('Public')]
+        [string]$ClientType = 'Public',
 
         [Parameter()]
         [int]$TimeoutInSeconds = 120,
@@ -218,7 +222,7 @@ function Get-AWSSSORoleCredential {
 
     if ($RefreshAccessToken) {
 
-        $Client = Register-SSOOIDCClient -ClientName $ClientName -ClientType 'Public' `
+        $Client = Register-SSOOIDCClient -ClientName $ClientName -ClientType $ClientType `
             -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())
         $DeviceAuth = Start-SSOOIDCDeviceAuthorization -ClientId $Client.ClientId -ClientSecret $Client.ClientSecret `
             -StartUrl $StartUrl -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -176,7 +176,7 @@ function Get-AWSSSORoleCredential {
     }
 
     if (Get-Module -Name $awsPowerShellModuleName -ListAvailable) {
-        Import-Module -Name $awsPowerShellModuleName
+        Import-Module -Name $awsPowerShellModuleName -Verbose:$false
     }
 
     if ($Region) {
@@ -315,7 +315,7 @@ function Get-AWSSSORoleCredential {
 
         foreach ($credential in $credentials) {
             if ($OutputAwsCredential) {
-                Write-Verbose -Message 'Returning the credentials as an Amazon.Runtime.SessionAWSCredentials object'
+                Write-Verbose -Message 'Outputting the credentials as an Amazon.Runtime.SessionAWSCredentials object'
                 New-AWSCredential -AccessKey $credential.AccessKey -SecretKey $credential.SecretKey `
                     -SessionToken $credential.SessionToken -Verbose:$false
             }
@@ -357,7 +357,7 @@ function Get-AWSSSORoleCredential {
                 $env:AWS_SESSION_TOKEN = $credential.SessionToken
             }
             else {
-                Write-Verbose -Message "Returning the Credentials as a PSCustomObject"
+                Write-Verbose -Message "Outputting the Credentials as a PSCustomObject"
                 $credential
             }
         }

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -48,51 +48,51 @@
     Used to specify the name and location of the ini-format credential file (shared with the AWS CLI and other
     AWS SDKs).
 .EXAMPLE
-    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start"
+    Get-AWSSSORoleCredential -StartUrl 'https://mycompany.awsapps.com/start'
 
     Prompt for account and role as applicable and output the credentials as a PSCustomObject.
 .EXAMPLE
-    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles
+    Get-AWSSSORoleCredential -StartUrl 'https://mycompany.awsapps.com/start' -AllAccountRoles
 
     Output all account and role credentials as an array of PSCustomObjects.
 .EXAMPLE
-    $RoleCredentials = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -PassThru
+    $RoleCredentials = Get-AWSSSORoleCredential -StartUrl 'https://mycompany.awsapps.com/start' -PassThru
     Get-S3Bucket @RoleCredentials
 
     Prompt for account and role as applicable and output as a hashtable for splatting on an AWS PowerShell cmdlet.
 .EXAMPLE
-    $AllRoleCredentials = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles
+    $AllRoleCredentials = Get-AWSSSORoleCredential -StartUrl 'https://mycompany.awsapps.com/start' -AllAccountRoles
     $AllRoleCredentials | Foreach-Object { Get-S3Bucket -AccessKey $_.AccessKey -SecretKey $_.SecretKey -SessionToken $_.SessionToken }
 
     Output all account and role credentials as an array of PSCustomObjects and pipe the properties through
     ForEach-Object to an AWS PowerShell cmdlet.
 .EXAMPLE
-    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -OutputEnvVariables
+    Get-AWSSSORoleCredential -StartUrl 'https://mycompany.awsapps.com/start' -OutputEnvVariables
     aws s3 ls
 
     Prompt for account and role as applicable and write to the AWS environment variables for use by the AWS ClI and
     other compatible tooling (Terraform, Sceptre etc).
 .EXAMPLE
-    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles -UseProfile
+    Get-AWSSSORoleCredential -StartUrl 'https://mycompany.awsapps.com/start' -AllAccountRoles -UseProfile
     Get-S3Bucket -Profile aws-account-01.SSORole1
 
     Output all account and role credentials to profiles within the AWS .NET SDK encrypted credential file with a
     naming convention of <AccountName>.<RoleName>.
 .EXAMPLE
-    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles -UseProfile -UseCliCredentialFile
+    Get-AWSSSORoleCredential -StartUrl 'https://mycompany.awsapps.com/start' -AllAccountRoles -UseProfile -UseCliCredentialFile
     aws s3 ls --profile aws-account-01.SSORole1
 
     Output all account and role credentials to profiles within the AWS CLI credential file with a naming convention of
     <AccountName>.<RoleName> for use by the AWS CLI.
 
 .EXAMPLE
-    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AccountId 123456789012 -RoleName SSORole1 -UseStoredAwsCredentials
+    Get-AWSSSORoleCredential -StartUrl 'https://mycompany.awsapps.com/start' -AccountId 123456789012 -RoleName SSORole1 -UseStoredAwsCredentials
     Get-S3Bucket
 
     Get credentials for the specified account ID and role name and write them to the AWS $StoredAwsCredentials variable
     for use by AWS PowerShell cmdlets.
 .EXAMPLE
-    $awsCredential = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AccountId 123456789012 -RoleName SSORole1 -OutputAwsCredential
+    $awsCredential = Get-AWSSSORoleCredential -StartUrl 'https://mycompany.awsapps.com/start' -AccountId 123456789012 -RoleName SSORole1 -OutputAwsCredential
     Get-S3Bucket -Credential $awsCredential
 
     Get credentials for the specified account ID and role name and output them as an Amazon.Runtime.SessionAWSCredentials
@@ -139,6 +139,8 @@ function Get-AWSSSORoleCredential {
         [switch]$PassThru,
 
         [Parameter()]
+        [string]$ClientName = 'default',
+
         [Parameter()]
         [ValidateSet('Public')]
         [string]$ClientType = 'Public',
@@ -147,7 +149,7 @@ function Get-AWSSSORoleCredential {
         [int]$TimeoutInSeconds = 120,
 
         [Parameter()]
-        [string]$Path = (Join-Path $Home ".awsssohelper"),
+        [string]$Path = (Join-Path $Home '.awsssohelper'),
 
         [Parameter(ParameterSetName = 'OutputAwsCredential')]
         [switch]$OutputAwsCredential,
@@ -207,7 +209,7 @@ function Get-AWSSSORoleCredential {
                 -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false | Out-Null
         }
         catch {
-            Write-Host "Cached access token is no longer valid, will need to obtain via SSO."
+            Write-Host 'Cached access token is no longer valid, will need to obtain via SSO.'
             $RefreshAccessToken = $true
         }
     }
@@ -240,7 +242,7 @@ function Get-AWSSSORoleCredential {
         }
         
         Clear-Variable AccessToken -ErrorAction SilentlyContinue
-        Write-Host "Waiting for SSO login via browser..."
+        Write-Host 'Waiting for SSO login via browser...'
         $SSOStart = Get-Date
         
         while (!$AccessToken -and ((New-TimeSpan $SSOStart (Get-Date)).TotalSeconds -lt $TimeoutInSeconds)) {
@@ -250,7 +252,7 @@ function Get-AWSSSORoleCredential {
                     ClientSecret = $Client.ClientSecret
                     Code         = $DeviceAuth.Code
                     DeviceCode   = $DeviceAuth.DeviceCode
-                    GrantType    = "urn:ietf:params:oauth:grant-type:device_code"
+                    GrantType    = 'urn:ietf:params:oauth:grant-type:device_code'
                     Credential   = ([Amazon.Runtime.AnonymousAWSCredentials]::new())
                 }
                 $AccessToken = New-SSOOIDCToken @newSSOIDCTokenParms
@@ -273,13 +275,13 @@ function Get-AWSSSORoleCredential {
             -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false
     }
     catch {
-        throw ("Error obtaining account list, access token is invalid.  Try running the command again with " +
+        throw ('Error obtaining account list, access token is invalid.  Try running the command again with ' +
             "'-RefreshAccessToken' parameter.")
     }
 
     if (!$AccountId) {
         if (!$AllAccountRoles) {
-            $outGridViewParms = @{ }
+            $outGridViewParms = @{}
             if ($UseStoredAwsCredentials) {
                 $outGridViewParms.Title = 'Select AWS Account'
                 $outGridViewParms.OutputMode = 'Single'
@@ -330,7 +332,7 @@ function Get-AWSSSORoleCredential {
                 Set-AWSCredential @setAwsCredentialParms
             }
             elseif ($UseStoredAwsCredentials) {
-                Write-Verbose -Message "Storing the credentials in the StoredAwsCredentials Global Variable"
+                Write-Verbose -Message 'Storing the credentials in the $StoredAwsCredentials Global Variable'
                 $setAwsCredentialParms = @{
                     AccessKey    = $credential.AccessKey
                     SecretKey    = $credential.SecretKey
@@ -347,7 +349,7 @@ function Get-AWSSSORoleCredential {
                 $env:AWS_SESSION_TOKEN = $credential.SessionToken
             }
             else {
-                Write-Verbose -Message "Outputting the Credentials as a PSCustomObject"
+                Write-Verbose -Message 'Outputting the Credentials as a PSCustomObject'
                 $credential
             }
         }
@@ -372,7 +374,7 @@ function GetAccountRoleCredential {
             $AccountRoles = ($SSORoles | Select-Object -First 1).RoleName
         }
         elseif (!$AllAccountRoles) {
-            $AccountRoles = ($SSORoles | Out-GridView -PassThru -Title "Select AWS SSO Role").RoleName
+            $AccountRoles = ($SSORoles | Out-GridView -PassThru -Title 'Select AWS SSO Role').RoleName
         }
         else {
             $AccountRoles = $SSORoles.RoleName

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -381,12 +381,17 @@ function GetAccountRoleCredential {
         $SSORoleCredential = Get-SSORoleCredential -AccessToken $AccessToken -AccountId $AccountId -RoleName $role `
             -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false
     
+        $SSOAccountName = (Get-SSOAccountList -AccessToken $AccessToken `
+            -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false |
+                Where-Object -Property AccountId -EQ $AccountID).AccountName
+
         $Credentials += [pscustomobject][ordered]@{
-            AccountId    = $AccountId;
-            RoleName     = $role;
-            AccessKey    = $SSORoleCredential.AccessKeyId;
-            Expiration   = $SSORoleCredential.Expiration;
-            SecretKey    = $SSORoleCredential.SecretAccessKey;
+            AccountId    = $AccountId
+            AccountName  = $SSOAccountName
+            RoleName     = $role
+            AccessKey    = $SSORoleCredential.AccessKeyId
+            Expiration   = $SSORoleCredential.Expiration
+            SecretKey    = $SSORoleCredential.SecretAccessKey
             SessionToken = $SSORoleCredential.SessionToken
         }
     }

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -218,7 +218,7 @@ function Get-AWSSSORoleCredential {
 
     if ($RefreshAccessToken) {
 
-        $Client = Register-SSOOIDCClient -ClientName $ClientName -ClientType $ClientType `
+        $Client = Register-SSOOIDCClient -ClientName $ClientName -ClientType 'Public' `
             -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())
         $DeviceAuth = Start-SSOOIDCDeviceAuthorization -ClientId $Client.ClientId -ClientSecret $Client.ClientSecret `
             -StartUrl $StartUrl -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -113,6 +113,7 @@ function Get-AWSSSORoleCredential {
         [Parameter(ParameterSetName = 'UseStoredAwsCredentials')]
         [Parameter(ParameterSetName = 'UseProfile')]
         [Parameter(ParameterSetName = 'OutputEnvVariables')]
+        [Parameter(ParameterSetName = 'UseProfileAllAccountRoles')]
         [string]$AccountId,
 
         [Parameter(ParameterSetName = 'OutputPSObject')]
@@ -123,40 +124,45 @@ function Get-AWSSSORoleCredential {
         [string]$RoleName,
 
         [Parameter(ParameterSetName = 'OutputPSObject')]
-        [Parameter(ParameterSetName = 'UseProfile')]
+        [Parameter(ParameterSetName = 'UseProfileAllAccountRoles')]
         [switch]$AllAccountRoles,
 
         [Parameter()]
         [switch]$RefreshAccessToken,
 
         [Parameter()]
-        [String]$Region,
+        [string]$Region,
 
         [Parameter(ParameterSetName = 'OutputPSObject')]
-        [Switch]$PassThru,
+        [switch]$PassThru,
 
         [Parameter()]
-        [String]$ClientName = "default",
+        [string]$ClientName = "default",
 
         [Parameter()]
         [int]$TimeoutInSeconds = 120,
 
         [Parameter()]
-        [String]$Path = (Join-Path $Home ".awsssohelper"),
+        [string]$Path = (Join-Path $Home ".awsssohelper"),
 
         [Parameter(ParameterSetName = 'OutputAwsCredential')]
-        [Switch]$OutputAwsCredential,
+        [switch]$OutputAwsCredential,
 
         [Parameter(ParameterSetName = 'UseStoredAwsCredentials')]
-        [Switch]$UseStoredAwsCredentials,
+        [switch]$UseStoredAwsCredentials,
 
         [Parameter(ParameterSetName = 'UseProfile')]
-        [Switch]$UseProfile,
+        [Parameter(ParameterSetName = 'UseProfileAllAccountRoles')]
+        [switch]$UseProfile,
 
         [Parameter(ParameterSetName = 'UseProfile')]
-        [Switch]$UseCliCredentialFile,
+        [Parameter(ParameterSetName = 'UseProfileAllAccountRoles')]
+        [switch]$UseCliCredentialFile,
 
         [Parameter(ParameterSetName = 'UseProfile')]
+        [Parameter(ParameterSetName = 'UseProfileAllAccountRoles')]
+        [string]$ProfileLocation = "$HOME\.aws\credentials",
+
         [Parameter(ParameterSetName = 'OutputEnvVariables')]
         [switch]$OutputEnvVariables
     )

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -264,14 +264,14 @@ function Get-AWSSSORoleCredential {
 
     }
 
-        try {
+    try {
         $awsAccounts = Get-SSOAccountList -AccessToken $AccessToken.AccessToken `
-                -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false
-        }
-        catch {
-            throw ("Error obtaining account list, access token is invalid.  Try running the command again with " +
-                "'-RefreshAccessToken' parameter.")
-        }
+            -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false
+    }
+    catch {
+        throw ("Error obtaining account list, access token is invalid.  Try running the command again with " +
+            "'-RefreshAccessToken' parameter.")
+    }
 
     if (!$AccountId) {
         if (!$AllAccountRoles) {
@@ -298,21 +298,6 @@ function Get-AWSSSORoleCredential {
     foreach ($account in $accounts) {
         $credentials = GetAccountRoleCredential -AccountId $account.AccountId -AccessToken $AccessToken.AccessToken `
             -RoleName $RoleName -AllAccountRoles:$AllAccountRoles
-
-        if ($UseProfile) {
-            try {
-                $getIamAccountAliasParms = @{
-                    AccessKey    = $credentials[0].AccessKey
-                    SecretKey    = $credentials[0].SecretKey
-                    SessionToken = $credentials[0].SessionToken
-                    Verbose      = $false
-                }
-                $accountName = Get-IamAccountAlias @getIamAccountAliasParms
-            }
-            catch {
-                $accountName = $accountId
-            }
-        }
 
         foreach ($credential in $credentials) {
             if ($OutputAwsCredential) {
@@ -396,7 +381,7 @@ function GetAccountRoleCredential {
     foreach ($role in $AccountRoles -split ' ') {
         $SSORoleCredential = Get-SSORoleCredential -AccessToken $AccessToken -AccountId $AccountId -RoleName $role `
             -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false
-    
+
         $SSOAccountName = (Get-SSOAccountList -AccessToken $AccessToken `
             -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false |
                 Where-Object -Property AccountId -EQ $AccountID).AccountName

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -252,7 +252,7 @@ function Get-AWSSSORoleCredential {
                 $AccessToken = New-SSOOIDCToken @newSSOIDCTokenParms
             }
             catch {
-                Write-Debug ($_.Exception.GetType().FullName, $_.Exception.Message)
+                Write-Debug -Message ($_.Exception.GetType().FullName, $_.Exception.Message | Out-String)
                 Start-Sleep -Seconds 5
             }
         }

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -44,7 +44,7 @@ function Get-AWSSSORoleCredential {
         [string]$Path = (Join-Path $Home ".awsssohelper")
     )
 
-    # Manually import the AWSPowerShell module if present as it is not configured for auto-loading
+    # Manually import the AWSPowerShell.NetCore module if present as it is not configured for auto-loading
     if ($PSVersionTable.PSEdition -ne 'Core') {
         $awsPowerShellModuleName = 'AWSPowerShell'
     }
@@ -52,7 +52,7 @@ function Get-AWSSSORoleCredential {
         $awsPowerShellModuleName = 'AWSPowerShell.NetCore'
     }
 
-    if ((Get-Module -Name $awsPowerShellModuleName -ListAvailable).Count -gt 0)
+    if (Get-Module -Name $awsPowerShellModuleName -ListAvailable)
     {
         Import-Module -Name $awsPowerShellModuleName
     }
@@ -118,6 +118,7 @@ function Get-AWSSSORoleCredential {
                 $AccessToken = New-SSOOIDCToken -ClientId $Client.ClientId -ClientSecret $Client.ClientSecret -Code $DeviceAuth.Code -DeviceCode $DeviceAuth.DeviceCode -GrantType "urn:ietf:params:oauth:grant-type:device_code" -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())
             }
             catch {
+                # Write-Host $_.Exception.GetType().FullName, $_.Exception.Message
                 Start-Sleep -Seconds 5
             }
         }
@@ -202,9 +203,8 @@ function GetAccountRoleCredential {
             }
         }
         return $return
+        # return $Credentials | Select-Object AccessKey,SecretKey,SessionToken
     }
 
     return $Credentials
 }
-
-Export-ModuleMember -Function 'Get-AWSSSORoleCredential'

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -19,7 +19,9 @@
 .PARAMETER AllAccountRoles
     If specified, credentials for all roles and accounts will be obtained.
 .PARAMETER ClientName
+    The friendly name for the SSO OIDC Client.
 .PARAMETER RefreshAccessToken
+    If specified, the SSO access token will be refreshed.
 .PARAMETER Region
     The system name of an AWS region where the AWS SSO service resides.
 .PARAMETER PassThru
@@ -35,36 +37,69 @@
     If specified, the credentials will be stored in the shell variable $StoredAWSCredentials for use by other AWS
     PowerShell cmdlets.
 .PARAMETER UseProfile
-    If specified then this function will store the credentials as an AWS profile.
+    If specified then this function will store the credentials as an AWS profile in the encrypted credential file used
+    by the AWS SDK for .NET and AWS Toolkit for Visual Studio.
 .PARAMETER UseCliCredentialFile
     If specified then this function will store the credentials in the CLI ini-format credential file at the location
-    specified by the ProfileLocation parameter. Otherwise the function will store the credentials in the encrypted 
-    credential file used by the AWS SDK for .NET and AWS Toolkit for Visual Studio.
+    specified by the ProfileLocation parameter rather than the AWS SDK .NET encrypted credential file.
 .PARAMETER ProfileLocation
     Used to specify the name and location of the ini-format credential file (shared with the AWS CLI and other
     AWS SDKs).
 .EXAMPLE
     Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start"
+
+    Prompt for account and role as applicable and output the credentials as a PSCustomObject.
 .EXAMPLE
     Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles
+
+    Output all account and role credentials as an array of PSCustomObjects.
 .EXAMPLE
     $RoleCredentials = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -PassThru
     Get-S3Bucket @RoleCredentials
+
+    Prompt for account and role as applicable and output as a hashtable for splatting on an AWS PowerShell cmdlet.
 .EXAMPLE
     $AllRoleCredentials = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles
     $AllRoleCredentials | Foreach-Object { Get-S3Bucket -AccessKey $_.AccessKey -SecretKey $_.SecretKey -SessionToken $_.SessionToken }
+
+    Output all account and role credentials as an array of PSCustomObjects and pipe the properties through
+    ForEach-Object to an AWS PowerShell cmdlet.
+.EXAMPLE
+    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -OutputEnvVariables
+    aws s3 ls
+
+    Prompt for account and role as applicable and write to the AWS environment variables for use by the AWS ClI and
+    other compatible tooling (Terraform, Sceptre etc).
+.EXAMPLE
+    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles -UseProfile
+    Get-S3Bucket -Profile aws-account-01.SSORole1
+
+    Output all account and role credentials to profiles within the AWS .NET SDK encrypted credential file with a
+    naming convention of <AccountName>.<RoleName>.
+.EXAMPLE
+    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles -UseProfile -UseCliCredentialFile
+    aws s3 ls --profile aws-account-01.SSORole1
+
+    Output all account and role credentials to profiles within the AWS CLI credential file with a naming convention of
+    <AccountName>.<RoleName> for use by the AWS CLI.
+
+.EXAMPLE
+    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AccountId 123456789012 -RoleName SSORole1 -UseStoredAwsCredentials
+    Get-S3Bucket
+
+    Get credentials for the specified account ID and role name and write them to the AWS $StoredAwsCredentials variable
+    for use by AWS PowerShell cmdlets.
+.EXAMPLE
+    $awsCredential = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AccountId 123456789012 -RoleName SSORole1 -OutputAwsCredential
+    Get-S3Bucket -Credential $awsCredential
+
+    Get credentials for the specified account ID and role name and output them as an Amazon.Runtime.SessionAWSCredentials
+    object for use by AWS PowerShell cmdlets.
 .INPUTS
-    StartUrl (Mandatory)
+    None
 .OUTPUTS
-    AccountId, RoleName, AccessKey, Expiration, SecretKey, SessionToken
-.NOTES
-    General notes
-.COMPONENT
-    The component this cmdlet belongs to
-.ROLE
-    The role this cmdlet belongs to
-.FUNCTIONALITY
-    The functionality that best describes this cmdlet
+    System.Management.Automation.PSObject
+    Amazon.Runtime.SessionAWSCredentials
 #>
 
 function Get-AWSSSORoleCredential {

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -112,12 +112,14 @@ function Get-AWSSSORoleCredential {
         [Parameter(ParameterSetName = 'OutputAwsCredential')]
         [Parameter(ParameterSetName = 'UseStoredAwsCredentials')]
         [Parameter(ParameterSetName = 'UseProfile')]
+        [Parameter(ParameterSetName = 'OutputEnvVariables')]
         [string]$AccountId,
 
         [Parameter(ParameterSetName = 'OutputPSObject')]
         [Parameter(ParameterSetName = 'OutputAwsCredential')]
         [Parameter(ParameterSetName = 'UseStoredAwsCredentials')]
         [Parameter(ParameterSetName = 'UseProfile')]
+        [Parameter(ParameterSetName = 'OutputEnvVariables')]
         [string]$RoleName,
 
         [Parameter(ParameterSetName = 'OutputPSObject')]
@@ -155,7 +157,8 @@ function Get-AWSSSORoleCredential {
         [Switch]$UseCliCredentialFile,
 
         [Parameter(ParameterSetName = 'UseProfile')]
-        [String]$ProfileLocation = "$HOME\.aws\credentials"
+        [Parameter(ParameterSetName = 'OutputEnvVariables')]
+        [switch]$OutputEnvVariables
     )
 
     # Manually import the AWSPowerShell.NetCore module if present as it is not configured for auto-loading
@@ -340,6 +343,12 @@ function Get-AWSSSORoleCredential {
                     Verbose      = $false
                 }
                 Set-AWSCredential @setAwsCredentialParms
+            }
+            elseif ($OutputEnvVariables) {
+                Write-Verbose -Message 'Outputting the credentials as the AWS environment variables'
+                $env:AWS_ACCESS_KEY_ID = $credential.AccessKey
+                $env:AWS_SECRET_ACCESS_KEY = $credential.SecretKey
+                $env:AWS_SESSION_TOKEN = $credential.SessionToken
             }
             else {
                 Write-Verbose -Message "Returning the Credentials as a PSCustomObject"

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -1,10 +1,48 @@
 <#
 .SYNOPSIS
-This is a simple utility script that allows you to retrieve credentials for AWS accounts that are secured using AWS SSO.  Access tokens are cached locally to prevent the need to be pushed to a web browser each time you invoke the script (this is similar behaviour to aws cli v2).
+    This is a simple utility script that allows you to retrieve credentials for AWS accounts that are secured using AWS SSO.
 .DESCRIPTION
-This is a simple utility script that allows you to retrieve credentials for AWS accounts that are secured using AWS SSO.  Access tokens are cached locally to prevent the need to be pushed to a web browser each time you invoke the script (this is similar behaviour to aws cli v2).
+    This is a simple utility script that allows you to retrieve credentials for AWS accounts that are secured using AWS SSO.
+    Access tokens are cached locally to prevent the need to be pushed to a web browser each time you invoke the script
+    (this is similar behaviour to aws cli v2).
 
-Main usability enhancement compared to aws cli 2 is the abillity to specify the -AllRoleCredentials switch and retrieve all credentials for all accounts that you have access to.  You will be prompted to select a role where you have access to multiple roles for an account, alternatively you can specify a role by using the -RoleName parameter.
+    Main usability enhancement compared to aws cli 2 is the abillity to specify the -AllRoleCredentials switch and retrieve
+    all credentials for all accounts that you have access to.  You will be prompted to select a role where you have access
+    to multiple roles for an account, alternatively you can specify a role by using the -RoleName parameter.
+.PARAMETER StartUrl
+    The URL for the AWS SSO user portal. For more information, see Using the User Portal in the AWS Single Sign-On User
+    Guide.
+.PARAMETER AccountId 
+    The ID of the AWS Account to use for filtering roles.
+.PARAMETER RoleName
+    The name of the role to use for filtering roles.
+.PARAMETER AllAccountRoles
+    If specified, credentials for all roles and accounts will be obtained.
+.PARAMETER ClientName
+.PARAMETER RefreshAccessToken
+.PARAMETER Region
+    The system name of an AWS region where the AWS SSO service resides.
+.PARAMETER PassThru
+    If specified, only the AccessKey, SecretKey and SessionToken are returned.
+.PARAMETER TimeoutInSeconds
+    The maximum length of time to wait for a token response from AWS SSO.
+.PARAMETER Path
+    The directory for storing the AWSSSOHelper access token cache
+.PARAMETER OutputAwsCredential
+    If specified, an AWSCredential object will be returned which can be used as input for the Credential parameter on
+    other AWS PowerShell cmdlets.
+.PARAMETER UseStoredAwsCredentials
+    If specified, the credentials will be stored in the shell variable $StoredAWSCredentials for use by other AWS
+    PowerShell cmdlets.
+.PARAMETER UseProfile
+    If specified then this function will store the credentials as an AWS profile.
+.PARAMETER UseCliCredentialFile
+    If specified then this function will store the credentials in the CLI ini-format credential file at the location
+    specified by the ProfileLocation parameter. Otherwise the function will store the credentials in the encrypted 
+    credential file used by the AWS SDK for .NET and AWS Toolkit for Visual Studio.
+.PARAMETER ProfileLocation
+    Used to specify the name and location of the ini-format credential file (shared with the AWS CLI and other
+    AWS SDKs).
 .EXAMPLE
     Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start"
 .EXAMPLE
@@ -30,18 +68,59 @@ Main usability enhancement compared to aws cli 2 is the abillity to specify the 
 #>
 
 function Get-AWSSSORoleCredential {
+    [CmdletBinding(DefaultParameterSetName = 'OutputPSObject')]
     param(
-        [Parameter(Mandatory=$true)][string]$StartUrl,
+        [Parameter(Mandatory = $true)]
+        [string]$StartUrl,
+
+        [Parameter(ParameterSetName = 'OutputPSObject')]
+        [Parameter(ParameterSetName = 'OutputAwsCredential')]
+        [Parameter(ParameterSetName = 'UseStoredAwsCredentials')]
+        [Parameter(ParameterSetName = 'UseProfile')]
         [string]$AccountId,
+
+        [Parameter(ParameterSetName = 'OutputPSObject')]
+        [Parameter(ParameterSetName = 'OutputAwsCredential')]
+        [Parameter(ParameterSetName = 'UseStoredAwsCredentials')]
+        [Parameter(ParameterSetName = 'UseProfile')]
         [string]$RoleName,
+
+        [Parameter(ParameterSetName = 'OutputPSObject')]
+        [Parameter(ParameterSetName = 'UseProfile')]
         [switch]$AllAccountRoles,
+
+        [Parameter()]
         [switch]$RefreshAccessToken,
-        [string]$Region,
-        [switch]$PassThru,
-        [string]$ClientName = "default",
-        [ValidateSet('public')][string]$ClientType = "public",
+
+        [Parameter()]
+        [String]$Region,
+
+        [Parameter(ParameterSetName = 'OutputPSObject')]
+        [Switch]$PassThru,
+
+        [Parameter()]
+        [String]$ClientName = "default",
+
+        [Parameter()]
         [int]$TimeoutInSeconds = 120,
-        [string]$Path = (Join-Path $Home ".awsssohelper")
+
+        [Parameter()]
+        [String]$Path = (Join-Path $Home ".awsssohelper"),
+
+        [Parameter(ParameterSetName = 'OutputAwsCredential')]
+        [Switch]$OutputAwsCredential,
+
+        [Parameter(ParameterSetName = 'UseStoredAwsCredentials')]
+        [Switch]$UseStoredAwsCredentials,
+
+        [Parameter(ParameterSetName = 'UseProfile')]
+        [Switch]$UseProfile,
+
+        [Parameter(ParameterSetName = 'UseProfile')]
+        [Switch]$UseCliCredentialFile,
+
+        [Parameter(ParameterSetName = 'UseProfile')]
+        [String]$ProfileLocation = "$HOME\.aws\credentials"
     )
 
     # Manually import the AWSPowerShell.NetCore module if present as it is not configured for auto-loading
@@ -52,8 +131,7 @@ function Get-AWSSSORoleCredential {
         $awsPowerShellModuleName = 'AWSPowerShell.NetCore'
     }
 
-    if (Get-Module -Name $awsPowerShellModuleName -ListAvailable)
-    {
+    if (Get-Module -Name $awsPowerShellModuleName -ListAvailable) {
         Import-Module -Name $awsPowerShellModuleName
     }
 
@@ -61,7 +139,8 @@ function Get-AWSSSORoleCredential {
         Set-DefaultAWSRegion $Region
     }
     elseif (($null -eq (Get-DefaultAWSRegion).Region)) {
-        throw "No default AWS region configured, specify '-Region <region>' parameter or configure defaults using 'Set-DefaultAWSRegion'."
+        throw ("No default AWS region configured, specify '-Region <region>' parameter or configure defaults using " +
+            "'Set-DefaultAWSRegion'.")
     }
     else {
         $Region = (Get-DefaultAWSRegion).Region
@@ -76,7 +155,8 @@ function Get-AWSSSORoleCredential {
     if (Test-Path $CachePath) {
         $AccessToken = Get-Content $CachePath -ErrorAction SilentlyContinue | ConvertFrom-Json
         try {
-            Get-SSOAccountList -AccessToken $AccessToken.AccessToken  -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) | Out-Null
+            Get-SSOAccountList -AccessToken $AccessToken.AccessToken `
+                -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false | Out-Null
         }
         catch {
             Write-Host "Cached access token is no longer valid, will need to obtain via SSO."
@@ -94,8 +174,10 @@ function Get-AWSSSORoleCredential {
 
     if ($RefreshAccessToken) {
 
-        $Client = Register-SSOOIDCClient -ClientName $ClientName -ClientType $ClientType -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())
-        $DeviceAuth = Start-SSOOIDCDeviceAuthorization -ClientId $Client.ClientId -ClientSecret $Client.ClientSecret -StartUrl $StartUrl -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())
+        $Client = Register-SSOOIDCClient -ClientName $ClientName -ClientType $ClientType `
+            -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())
+        $DeviceAuth = Start-SSOOIDCDeviceAuthorization -ClientId $Client.ClientId -ClientSecret $Client.ClientSecret `
+            -StartUrl $StartUrl -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())
 
         try {
             $Process = Start-Process $DeviceAuth.VerificationUriComplete -PassThru
@@ -115,10 +197,18 @@ function Get-AWSSSORoleCredential {
         
         while (!$AccessToken -and ((New-TimeSpan $SSOStart (Get-Date)).TotalSeconds -lt $TimeoutInSeconds)) {
             try {
-                $AccessToken = New-SSOOIDCToken -ClientId $Client.ClientId -ClientSecret $Client.ClientSecret -Code $DeviceAuth.Code -DeviceCode $DeviceAuth.DeviceCode -GrantType "urn:ietf:params:oauth:grant-type:device_code" -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())
+                $newSSOIDCTokenParms = @{
+                    ClientId     = $Client.ClientId
+                    ClientSecret = $Client.ClientSecret
+                    Code         = $DeviceAuth.Code
+                    DeviceCode   = $DeviceAuth.DeviceCode
+                    GrantType    = "urn:ietf:params:oauth:grant-type:device_code"
+                    Credential   = ([Amazon.Runtime.AnonymousAWSCredentials]::new())
+                }
+                $AccessToken = New-SSOOIDCToken @newSSOIDCTokenParms
             }
             catch {
-                # Write-Host $_.Exception.GetType().FullName, $_.Exception.Message
+                Write-Debug ($_.Exception.GetType().FullName, $_.Exception.Message)
                 Start-Sleep -Seconds 5
             }
         }
@@ -132,13 +222,25 @@ function Get-AWSSSORoleCredential {
 
     if (!$AccountId) {
         try {
-            $AWSAccounts = Get-SSOAccountList -AccessToken $AccessToken.AccessToken  -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())
+            $AWSAccounts = Get-SSOAccountList -AccessToken $AccessToken.AccessToken `
+                -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false
         }
         catch {
-            throw "Error obtaining account list, access token is invalid.  Try running the command again with '-RefreshAccessToken' parameter."
+            throw ("Error obtaining account list, access token is invalid.  Try running the command again with " +
+                "'-RefreshAccessToken' parameter.")
         }
         if (!$AllAccountRoles) {
-            $AccountIds = ($AWSAccounts | Sort-Object AccountName | Out-GridView -PassThru -Title "Select AWS Account").AccountId
+            $outGridViewParms = @{ }
+            if ($UseStoredAwsCredentials) {
+                $outGridViewParms.Title = 'Select AWS Account'
+                $outGridViewParms.OutputMode = 'Single'
+            }
+            else {
+                $outGridViewParms.Title = 'Select AWS Account(s)'
+                $outGridViewParms.OutputMode = 'Multiple'
+            }
+
+            $AccountIds = ($AWSAccounts | Sort-Object AccountName | Out-GridView @outGridViewParms).AccountId
         }
         else {
             $AccountIds = $AWSAccounts | Select-Object -ExpandProperty AccountId
@@ -147,9 +249,69 @@ function Get-AWSSSORoleCredential {
     else {
         $AccountIds = $AccountId
     }
+    Write-Verbose "AccountId count: $($AccountIds.Count)"
+    foreach ($accountId in $AccountIds) {
+        $credentials = GetAccountRoleCredential -AccountId $accountId -AccessToken $AccessToken.AccessToken `
+            -RoleName $RoleName -AllAccountRoles:$AllAccountRoles
 
-    $AccountIds | ForEach-Object { GetAccountRoleCredential -AccountId $_ -AccessToken $AccessToken.AccessToken -RoleName $RoleName -AllAccountRoles:$AllAccountRoles }
+        if ($UseProfile) {
+            try {
+                $getIamAccountAliasParms = @{
+                    AccessKey    = $credentials[0].AccessKey
+                    SecretKey    = $credentials[0].SecretKey
+                    SessionToken = $credentials[0].SessionToken
+                    Verbose      = $false
+                }
+                $accountName = Get-IamAccountAlias @getIamAccountAliasParms
+            }
+            catch {
+                $accountName = $accountId
+            }
+        }
 
+        foreach ($credential in $credentials) {
+            if ($OutputAwsCredential) {
+                Write-Verbose -Message 'Returning the credentials as an Amazon.Runtime.SessionAWSCredentials object'
+                New-AWSCredential -AccessKey $credential.AccessKey -SecretKey $credential.SecretKey `
+                    -SessionToken $credential.SessionToken -Verbose:$false
+            }
+            elseif ($UseProfile) {
+                $profileName = "$accountName.$($credential.RoleName)"
+                $setAwsCredentialParms = @{
+                    StoreAs      = $profileName
+                    AccessKey    = $credential.AccessKey
+                    SecretKey    = $credential.SecretKey
+                    SessionToken = $credential.SessionToken
+                    Verbose      = $false
+                }
+                if ($UseCliCredentialFile) {
+                    Write-Verbose -Message (
+                        "Storing the credentials as AWS profile $profileName in the AWS CLI credential file")
+                    $setAwsCredentialParms.ProfileLocation = $ProfileLocation
+                }
+                else {
+                    Write-Verbose -Message (
+                        "Storing the credentials as AWS profile $profileName in the AWS .NET SDK Credential store")
+                }
+                Set-AWSCredential @setAwsCredentialParms
+            }
+            elseif ($UseStoredAwsCredentials) {
+                Write-Verbose -Message "Storing the credentials in the StoredAwsCredentials Global Variable"
+                $setAwsCredentialParms = @{
+                    AccessKey    = $credential.AccessKey
+                    SecretKey    = $credential.SecretKey
+                    SessionToken = $credential.SessionToken
+                    Scope        = 'Global'
+                    Verbose      = $false
+                }
+                Set-AWSCredential @setAwsCredentialParms
+            }
+            else {
+                Write-Verbose -Message "Returning the Credentials as a PSCustomObject"
+                $credential
+            }
+        }
+    }
 }
 
 function GetAccountRoleCredential {
@@ -164,7 +326,8 @@ function GetAccountRoleCredential {
     $Credentials = @()
 
     if (!$RoleName) {
-        $SSORoles = Get-SSOAccountRoleList -AccessToken $AccessToken -AccountId $AccountId -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())
+        $SSORoles = Get-SSOAccountRoleList -AccessToken $AccessToken -AccountId $AccountId `
+            -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false
         if ($SSORoles.Count -eq 1) {
             $AccountRoles = ($SSORoles | Select-Object -First 1).RoleName
         }
@@ -180,31 +343,31 @@ function GetAccountRoleCredential {
     }
 
     foreach ($role in $AccountRoles -split ' ') {
-        $SSORoleCredential = Get-SSORoleCredential -AccessToken $AccessToken -AccountId $AccountId -RoleName $role -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new())
+        $SSORoleCredential = Get-SSORoleCredential -AccessToken $AccessToken -AccountId $AccountId -RoleName $role `
+            -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false
     
         $Credentials += [pscustomobject][ordered]@{
-            AccountId = $AccountId;
-            RoleName = $role;
-            AccessKey = $SSORoleCredential.AccessKeyId;
-            Expiration = $SSORoleCredential.Expiration;
-            SecretKey = $SSORoleCredential.SecretAccessKey;
+            AccountId    = $AccountId;
+            RoleName     = $role;
+            AccessKey    = $SSORoleCredential.AccessKeyId;
+            Expiration   = $SSORoleCredential.Expiration;
+            SecretKey    = $SSORoleCredential.SecretAccessKey;
             SessionToken = $SSORoleCredential.SessionToken
         }
     }
-
 
     if ($PassThru) {
         $return = @()
         foreach ($item in $Credentials) {
             $return += @{
-                AccessKey = $item.AccessKey
-                SecretKey = $item.SecretKey
+                AccessKey    = $item.AccessKey
+                SecretKey    = $item.SecretKey
                 SessionToken = $item.SessionToken
             }
         }
         return $return
-        # return $Credentials | Select-Object AccessKey,SecretKey,SessionToken
     }
-
-    return $Credentials
+    else {
+        return $Credentials
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added support for AWS.Tools PowerShell Modules
   ([issue #2](https://github.com/e0c615c8e4d846ef817cd5063a88716c/AWSSSOHelper/issues/2)).
 - Added support for Windows Powershell v5.1
+- Added support for additional credential output options
+  ([issue #5](https://github.com/e0c615c8e4d846ef817cd5063a88716c/AWSSSOHelper/issues/5)).
 
 ## [0.0.21] - 2020-05-11
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The output options of the credentials can be selected from the following options
 - Output as an array of PSCustomObjects with the following properties: AccountId, RoleName, AccessKey, Expiration, SecretKey, SessionToken.
 - Output as an array of hashtables with the following keys: AccessKey, SecretKey, SessionToken. for splatting input to AWS PowerShell cmdlets.
 - Output as an `Amazon.Runtime.SessionAWSCredentials` object for input to the `Credential` parameter of AWS PowerShell cmdlets.
+- Output to the `$StoredAWSCredentials` shell variable for use by AWS PowerShell cmdlets.
 - Written as profiles to the AWS SDK .NET encrypted credential file used by the AWS PowerShell cmdlets with a naming convention of `<AccountName>.<RoleName>`.
 - Written as profiles to the AWS CLI ini-format credential file with a naming convention of `<AccountName>.<RoleName>`.
 - Written to the AWS CLI environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` for use by the AWS CLI and other compatible tooling (Terraform, Sceptre).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ This is a simple utility script that allows you to retrieve credentials for AWS 
 
 Main usability improvement compared to aws cli is the abillity to specify the -AllRoleCredentials switch and retrieve all credentials for all accounts that you have access to.  You will be prompted to select a role where you have access to multiple roles for an account, alternatively you can specify a role by using the -RoleName parameter.
 
+The output options of the credentials can be selected from the following options:
+
+- Output as an array of PSCustomObjects with the following properties: AccountId, RoleName, AccessKey, Expiration, SecretKey, SessionToken.
+- Output as an array of hashtables with the following keys: AccessKey, SecretKey, SessionToken. for splatting input to AWS PowerShell cmdlets.
+- Output as an `Amazon.Runtime.SessionAWSCredentials` object for input to the `Credential` parameter of AWS PowerShell cmdlets.
+- Written as profiles to the AWS SDK .NET encrypted credential file used by the AWS PowerShell cmdlets with a naming convention of `<AccountName>.<RoleName>`.
+- Written as profiles to the AWS CLI ini-format credential file with a naming convention of `<AccountName>.<RoleName>`.
+- Written to the AWS CLI environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` for use by the AWS CLI and other compatible tooling (Terraform, Sceptre).
+
 A basic set of functionality is included, potential future enhancements could be:
 
 - Additional logic to identify expired Session Tokens and automatically renew (safest for now is to renew ahead of any command execution) - **Done**
@@ -48,12 +57,52 @@ Install-Module AWSSSOHelper -Force
 ```powershell
 .EXAMPLE
     Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start"
+
+    Prompt for account and role as applicable and output the credentials as a PSCustomObject.
 .EXAMPLE
     Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles
+
+    Output all account and role credentials as an array of PSCustomObjects.
 .EXAMPLE
     $RoleCredentials = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -PassThru
     Get-S3Bucket @RoleCredentials
+
+    Prompt for account and role as applicable and output as a hashtable for splatting on an AWS PowerShell cmdlet.
 .EXAMPLE
     $AllRoleCredentials = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles
     $AllRoleCredentials | Foreach-Object { Get-S3Bucket -AccessKey $_.AccessKey -SecretKey $_.SecretKey -SessionToken $_.SessionToken }
+
+    Output all account and role credentials as an array of PSCustomObjects and pipe the properties through
+    ForEach-Object to an AWS PowerShell cmdlet.
+.EXAMPLE
+    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -OutputEnvVariables
+    aws s3 ls
+
+    Prompt for account and role as applicable and write to the AWS environment variables for use by the AWS ClI and
+    other compatible tooling (Terraform, Sceptre etc).
+.EXAMPLE
+    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles -UseProfile
+    Get-S3Bucket -Profile aws-account-01.SSORole1
+
+    Output all account and role credentials to profiles within the AWS .NET SDK encrypted credential file with a
+    naming convention of <AccountName>.<RoleName>.
+.EXAMPLE
+    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles -UseProfile -UseCliCredentialFile
+    aws s3 ls --profile aws-account-01.SSORole1
+
+    Output all account and role credentials to profiles within the AWS CLI credential file with a naming convention of
+    <AccountName>.<RoleName> for use by the AWS CLI.
+
+.EXAMPLE
+    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AccountId 123456789012 -RoleName SSORole1 -UseStoredAwsCredentials
+    Get-S3Bucket
+
+    Get credentials for the specified account ID and role name and write them to the AWS $StoredAwsCredentials variable
+    for use by AWS PowerShell cmdlets.
+.EXAMPLE
+    $awsCredential = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AccountId 123456789012 -RoleName SSORole1 -OutputAwsCredential
+    Get-S3Bucket -Credential $awsCredential
+
+    Get credentials for the specified account ID and role name and output them as an Amazon.Runtime.SessionAWSCredentials
+    object for use by AWS PowerShell cmdlets.
 ```


### PR DESCRIPTION
#### Description

This PR adds support for the following additional credential output options:

- Output as an `Amazon.Runtime.SessionAWSCredentials` object for input to the `Credential` parameter of AWS PowerShell cmdlets.
- Output to the `$StoredAWSCredentials` shell variable for use by AWS PowerShell cmdlets.
- Written as profiles to the AWS SDK .NET encrypted credential file used by the AWS PowerShell cmdlets with a naming convention of `<AccountName>.<RoleName>`.
- Written as profiles to the AWS CLI ini-format credential file with a naming convention of `<AccountName>.<RoleName>`.
- Written to the AWS CLI environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` for use by the AWS CLI and other compatible tooling (Terraform, Sceptre etc).

The following changes have also been made:

- Added Parameter descriptions to comment based help.
- Removed redundant comment based help sections.
- Added account name to `PSCustomObject` output.
- Removed redundant `Export-ModuleMember` call.

#### Issues Fixed

- Fixes #5 