### PR TITLE
Improvements to the token expiration logic

### DIFF
--- a/AWSSSOHelper.psd1
+++ b/AWSSSOHelper.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AWSSSOHelper.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.26'
+ModuleVersion = '0.0.27'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core','Desktop')

--- a/AWSSSOHelper.psd1
+++ b/AWSSSOHelper.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AWSSSOHelper.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.25'
+ModuleVersion = '0.0.26'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core','Desktop')

--- a/AWSSSOHelper.psd1
+++ b/AWSSSOHelper.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AWSSSOHelper.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.27'
+ModuleVersion = '0.0.28'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core','Desktop')

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -210,11 +210,10 @@ function Get-AWSSSORoleCredential {
             Write-Host 'Access token is null. A new access token will be obtained via SSO.'
         } else {
             try {
-                $accountList = Get-SSOAccountList -AccessToken $SSOCredentials.AWSToken.AccessToken `
-                    -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false | Out-Null
+                $accountList = Get-SSOAccountList -AccessToken $SSOCredentials.AWSToken.AccessToken -Credential ([Amazon.Runtime.AnonymousAWSCredentials]::new()) -Verbose:$false
             }
             catch {
-                Write-Host 'Cannot retrieve a cached access token. A new access token will be obtained via SSO.'
+                Write-Host 'Cached access token appears to be invalid. A new access token will be obtained via SSO.'
             }
         }
     }


### PR DESCRIPTION
This should improve the token expiration logic. The code adds an Expiration timestamp the in the JSON cache file and eliminates the LoggedAt test. The next time the Get-AWSSSORoleCredential function runs it will test if Get-Date is less than the Expiration timestamp. 